### PR TITLE
Allow building with servant-client 0.8 and 0.9

### DIFF
--- a/google-translate.cabal
+++ b/google-translate.cabal
@@ -21,10 +21,10 @@ library
                      , base           >= 4.7 && < 5
                      , bytestring     == 0.10.*
                      , transformers   >= 0.4 && < 0.6
-                     , http-api-data  == 0.2.*
-                     , http-client    == 0.4.*
-                     , servant        == 0.7.*
-                     , servant-client == 0.7.*
+                     , http-api-data  >= 0.2 && < 0.4
+                     , http-client    >= 0.4 && < 0.6
+                     , servant        >= 0.7 && < 0.10
+                     , servant-client >= 0.7 && < 0.10
                      , text           == 1.2.*
   default-language:    Haskell2010
 


### PR DESCRIPTION
Use CPP to allow the current servant-0.7 config too, so it just adds additional compatibility, doesn't take anything away or change the external API.
